### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,26 @@
-
 # agecache
 
-Creates an LRU cache with a set max age. The main difference between
-this and a simple LRU cache is that it will make sure to age out old entries.
+Thread-safe LRU cache supporting max age and expiration. Supports cache
+statistics, as well as eviction and expiration callbacks. Differs from
+some implementations in that OnEviction is only invoked when an entry
+is removed as a result of the LRU eviction policy - not when you explicitly
+delete it or when it expires. OnExpiration is available and invoked when an
+item expires. Expiration is passively enforced when performing a Get.
 
-The Agecache doesn't aim to be thread-safe (though the underlying
-implementation is). Instead, it aims to give fast access, maintaining the
-most recently used items, but expiring them after a certain time.
+``` go
+cache := agecache.New(agecache.Config{
+	Capacity: 100,
+	MaxAge:   time.Hour,
+	OnExpiration: func(key, value interface{}) {
+		// Handle expiration
+	},
+	OnEviction: func(key, value interface{}) {
+		// Handle eviction
+	},
+})
+
+cache.Set("foo", "bar")
+```
 
 ## Documentation
 

--- a/_example/stats.go
+++ b/_example/stats.go
@@ -2,32 +2,31 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/segmentio/agecache"
 )
 
 func main() {
-	c, err := agecache.New(100, time.Second)
-	if err != nil {
-		log.Fatalf("new: %s", err)
-	}
+	cache := agecache.New(agecache.Config{
+		Capacity: 100,
+		MaxAge:   time.Second,
+	})
 
-	c.Add("a", "1")
+	cache.Set("a", "1")
 
-	prev := c.Stats()
+	prev := cache.Stats()
 	tick := time.Tick(time.Millisecond * 100)
 
 	for range tick {
-		c.Get("a") // hit
-		c.Get("b") // miss
-		c.Get("a") // hit
+		cache.Get("a") // hit
+		cache.Get("b") // miss
+		cache.Get("a") // hit
 
-		stats := c.Stats().Sub(prev)
+		stats := cache.Stats().Delta(prev)
 		fmt.Println("hits", stats.Hits)
 		fmt.Println("misses", stats.Misses)
 
-		prev = c.Stats()
+		prev = cache.Stats()
 	}
 }

--- a/cache.go
+++ b/cache.go
@@ -1,91 +1,296 @@
+// LRU largely inspired by https://github.com/golang/groupcache
 package agecache
 
 import (
+	"container/list"
+	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
-
-	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 // Stats hold cache statistics.
 type Stats struct {
-	Hits   int64 // number of cache hits.
-	Misses int64 // number of cache misses
+	Capacity  int64 // Gauge, maximum capacity for the cache
+	Count     int64 // Gauge, number of items in the cache
+	Sets      int64 // Counter, number of sets
+	Gets      int64 // Counter, number of gets
+	Hits      int64 // Counter, number of cache hits from Get operations
+	Misses    int64 // Counter, number of cache misses from Get operations
+	Evictions int64 // Counter, number of evictions
 }
 
-// Sub subtracts stats `s` with `o`.
-func (s Stats) Sub(o Stats) Stats {
+// Delta returns a Stats object such that all counters are calculated as the
+// difference since the previous.
+func (stats Stats) Delta(previous Stats) Stats {
 	return Stats{
-		Hits:   atomic.LoadInt64(&s.Hits) - o.Hits,
-		Misses: atomic.LoadInt64(&s.Misses) - o.Misses,
+		Capacity:  stats.Capacity,
+		Count:     stats.Count,
+		Sets:      stats.Sets - previous.Sets,
+		Gets:      stats.Gets - previous.Gets,
+		Hits:      stats.Hits - previous.Hits,
+		Misses:    stats.Misses - previous.Misses,
+		Evictions: stats.Evictions - previous.Evictions,
 	}
 }
 
-type entry struct {
+// Configuration for the Cache.
+type Config struct {
+	// Maximum number of items in the cache
+	Capacity int
+	// Optional duration before an item expires. If zero, expiration is disabled
+	MaxAge time.Duration
+	// Optional callback invoked when an item is evicted due to the LRU policy
+	OnEviction func(key, value interface{})
+	// Optional callback invoked when an item expired
+	OnExpiration func(key, value interface{})
+}
+
+// Entry pointed to by each list.Element
+type cacheEntry struct {
+	key     interface{}
 	value   interface{}
 	created time.Time
 }
 
-// LRU implements a thread-safe fixed size LRU cache.
+// LRU implements a thread-safe fixed-capacity LRU cache.
 type Cache struct {
-	lru    *simplelru.LRU
-	mu     sync.Mutex
-	maxAge time.Duration
-	stats  Stats
+	// Fields defined by configuration
+	capacity     int
+	maxAge       time.Duration
+	onEviction   func(key, value interface{})
+	onExpiration func(key, value interface{})
+
+	// Cache statistics
+	sets      int64
+	gets      int64
+	hits      int64
+	misses    int64
+	evictions int64
+
+	items        map[interface{}]*list.Element
+	evictionList *list.List
+	mutex        sync.RWMutex
 }
 
-// New constructs an LRU of the given size and max age to return
-// results for
-func New(size int, maxAge time.Duration) (*Cache, error) {
-	l, err := simplelru.NewLRU(size, nil)
-	if err != nil {
-		return nil, err
+// New constructs an LRU Cache with the given Config object. config.Capacity
+// must be a positive int, and config.MaxAge a zero or positive duration. A
+// duration of zero disables item expiration. Panics given an invalid
+// config.Capacity or config.MaxAge.
+func New(config Config) *Cache {
+	if config.Capacity <= 0 {
+		panic("Must supply a positive config.Capacity")
 	}
 
-	c := &Cache{
-		lru:    l,
-		maxAge: maxAge,
+	if config.MaxAge < 0 {
+		panic("Must supply a zero or positive config.MaxAge")
 	}
 
-	return c, nil
+	cache := &Cache{
+		capacity:     config.Capacity,
+		maxAge:       config.MaxAge,
+		onEviction:   config.OnEviction,
+		onExpiration: config.OnExpiration,
+		items:        make(map[interface{}]*list.Element),
+		evictionList: list.New(),
+	}
+
+	return cache
 }
 
-// Add adds an additional key/value pair to our cache.
-func (c *Cache) Add(key, value interface{}) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// Set updates a key:value pair in the cache. Returns true if an eviction
+// occurrred, and subsequently invokes the OnEviction callback.
+func (cache *Cache) Set(key, value interface{}) bool {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
 
-	return c.lru.Add(key, entry{
-		value:   value,
-		created: time.Now(),
-	})
+	cache.sets++
+	created := time.Now()
+
+	if element, ok := cache.items[key]; ok {
+		cache.evictionList.MoveToFront(element)
+		entry := element.Value.(*cacheEntry)
+		entry.value = value
+		entry.created = created
+		return false
+	}
+
+	entry := &cacheEntry{key, value, created}
+	element := cache.evictionList.PushFront(entry)
+	cache.items[key] = element
+
+	evict := cache.evictionList.Len() > cache.capacity
+	if evict {
+		cache.evictOldest()
+	}
+	return evict
 }
 
-// Get returns the value stored at `key`.
-//
-// The boolean value reports if the value was found.
-func (c *Cache) Get(key interface{}) (interface{}, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// Get returns the value stored at `key`. The boolean value reports whether or
+// not the value was found. The OnExpiration callback is invoked if the value
+// had expired on access
+func (cache *Cache) Get(key interface{}) (interface{}, bool) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
 
-	val, ok := c.lru.Get(key)
-	if !ok {
-		c.stats.Misses++
-		return nil, ok
+	cache.gets++
+
+	if element, ok := cache.items[key]; ok {
+		entry := element.Value.(*cacheEntry)
+		if cache.maxAge == 0 || time.Since(entry.created) <= cache.maxAge {
+			cache.evictionList.MoveToFront(element)
+			cache.hits++
+			return entry.value, true
+		}
+
+		// Entry expired
+		cache.deleteElement(element)
+		cache.misses++
+		if cache.onExpiration != nil {
+			cache.onExpiration(entry.key, entry.value)
+		}
+		return nil, false
 	}
 
-	e := val.(entry)
-	if time.Since(e.created) <= c.maxAge {
-		c.stats.Hits++
-		return e.value, true
-	}
-
-	c.lru.Remove(key)
+	cache.misses++
 	return nil, false
 }
 
+// Has returns whether or not the `key` is in the cache without updating
+// how recently it was accessed or deleting it for having expired.
+func (cache *Cache) Has(key interface{}) bool {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	_, ok := cache.items[key]
+	return ok
+}
+
+// Peek returns the value at the specified key and a boolean specifying whether
+// or not it was found, without updating how recently it was accessed or
+// deleting it for having expired.
+func (cache *Cache) Peek(key interface{}) (interface{}, bool) {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	if element, ok := cache.items[key]; ok {
+		return element.Value.(*cacheEntry).value, true
+	}
+
+	return nil, false
+}
+
+// Remove removes the provided key from the cache, returning a bool indicating
+// whether or not it existed.
+func (cache *Cache) Remove(key interface{}) bool {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	if element, ok := cache.items[key]; ok {
+		cache.deleteElement(element)
+		return true
+	}
+
+	return false
+}
+
+// Len returns the number of items in the cache.
+func (cache *Cache) Len() int {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	return cache.evictionList.Len()
+}
+
+// Clear empties the cache.
+func (cache *Cache) Clear() {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	for _, val := range cache.items {
+		cache.deleteElement(val)
+	}
+	cache.evictionList.Init()
+}
+
+// Keys returns all keys in the cache.
+func (cache *Cache) Keys() []interface{} {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	keys := make([]interface{}, len(cache.items))
+	i := 0
+
+	for key := range cache.items {
+		keys[i] = key
+		i++
+	}
+
+	return keys
+}
+
+// OrderedKeys returns all keys in the cache, ordered from oldest to newest.
+func (cache *Cache) OrderedKeys() []interface{} {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	keys := make([]interface{}, len(cache.items))
+	i := 0
+
+	for element := cache.evictionList.Back(); element != nil; element = element.Prev() {
+		keys[i] = element.Value.(*cacheEntry).key
+		i++
+	}
+
+	return keys
+}
+
+// SetMaxAge updates the max age for items in the cache. A duration of zero
+// disables expiration. A negative duration results in an error.
+func (cache *Cache) SetMaxAge(maxAge time.Duration) error {
+	if maxAge < 0 {
+		return errors.New("Must supply a zero or positive maxAge")
+	}
+
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.maxAge = maxAge
+
+	return nil
+}
+
 // Stats returns cache stats.
-func (c *Cache) Stats() Stats {
-	return c.stats
+func (cache *Cache) Stats() Stats {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	return Stats{
+		Capacity:  int64(cache.capacity),
+		Count:     int64(cache.evictionList.Len()),
+		Sets:      cache.sets,
+		Gets:      cache.gets,
+		Hits:      cache.hits,
+		Misses:    cache.misses,
+		Evictions: cache.evictions,
+	}
+}
+
+func (cache *Cache) evictOldest() {
+	element := cache.evictionList.Back()
+	if element == nil {
+		return
+	}
+
+	cache.evictions++
+	entry := cache.deleteElement(element)
+	if cache.onEviction != nil {
+		cache.onEviction(entry.key, entry.value)
+	}
+}
+
+func (cache *Cache) deleteElement(element *list.Element) *cacheEntry {
+	cache.evictionList.Remove(element)
+	entry := element.Value.(*cacheEntry)
+	delete(cache.items, entry.key)
+	return entry
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,114 +1,299 @@
 package agecache
 
 import (
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAgeOut(t *testing.T) {
-	c, err := New(100, time.Millisecond)
+func TestInvalidCapacity(t *testing.T) {
+	assert.Panics(t, func() {
+		New(Config{Capacity: 0})
+	})
+}
+
+func TestInvalidMaxAge(t *testing.T) {
+	maxAge, err := time.ParseDuration("-1h")
 	assert.Nil(t, err)
 
-	c.Add("foo", "bar")
+	assert.Panics(t, func() {
+		New(Config{Capacity: 1, MaxAge: maxAge})
+	})
+}
+
+func TestBasicSetGet(t *testing.T) {
+	cache := New(Config{Capacity: 2})
+	cache.Set("foo", 1)
+	cache.Set("bar", 2)
+
+	val, ok := cache.Get("foo")
+	assert.True(t, ok)
+	assert.Equal(t, 1, val)
+
+	val, ok = cache.Get("bar")
+	assert.True(t, ok)
+	assert.Equal(t, 2, val)
+}
+
+func TestBasicSetOverwrite(t *testing.T) {
+	cache := New(Config{Capacity: 2})
+	cache.Set("foo", 1)
+	evict := cache.Set("foo", 2)
+	val, ok := cache.Get("foo")
+
+	assert.False(t, evict)
+	assert.True(t, ok)
+	assert.Equal(t, 2, val)
+}
+
+func TestEviction(t *testing.T) {
+	var k, v interface{}
+
+	cache := New(Config{
+		Capacity: 2,
+		OnEviction: func(key, value interface{}) {
+			k = key
+			v = value
+		},
+	})
+
+	cache.Set("foo", 1)
+	cache.Set("bar", 2)
+	evict := cache.Set("baz", 3)
+	val, ok := cache.Get("foo")
+
+	assert.True(t, evict)
+	assert.False(t, ok)
+	assert.Nil(t, val)
+	assert.Equal(t, "foo", k)
+	assert.Equal(t, 1, v)
+}
+
+func TestExpiration(t *testing.T) {
+	var k, v interface{}
+	var eviction bool
+
+	cache := New(Config{
+		Capacity: 1,
+		MaxAge:   time.Millisecond,
+		OnExpiration: func(key, value interface{}) {
+			k = key
+			v = value
+		},
+		OnEviction: func(key, value interface{}) {
+			eviction = true
+		},
+	})
+
+	cache.Set("foo", 1)
 	<-time.After(time.Millisecond * 2)
 
-	val, ok := c.Get("foo")
+	val, ok := cache.Get("foo")
+	assert.False(t, ok)
+	assert.Nil(t, val)
+	assert.Equal(t, "foo", k)
+	assert.Equal(t, 1, v)
+	assert.False(t, eviction)
+}
+
+func TestHas(t *testing.T) {
+	cache := New(Config{Capacity: 1, MaxAge: time.Millisecond})
+	cache.Set("foo", "bar")
+	<-time.After(time.Millisecond * 2)
+
+	ok := cache.Has("foo")
+	assert.True(t, ok)
+}
+
+func TestPeek(t *testing.T) {
+	cache := New(Config{Capacity: 1, MaxAge: time.Millisecond})
+	cache.Set("foo", "bar")
+	<-time.After(time.Millisecond * 2)
+
+	val, ok := cache.Peek("foo")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", val)
+}
+
+func TestRemove(t *testing.T) {
+	var eviction bool
+
+	cache := New(Config{
+		Capacity: 1,
+		OnEviction: func(key, value interface{}) {
+			eviction = true
+		},
+	})
+
+	cache.Set("foo", "bar")
+	ok := cache.Remove("foo")
+
+	assert.True(t, ok)
+	assert.False(t, eviction)
+
+	val, ok := cache.Get("foo")
 	assert.False(t, ok)
 	assert.Nil(t, val)
 }
 
-func TestTooManyItems(t *testing.T) {
-	c, err := New(1, time.Minute)
+func TestLen(t *testing.T) {
+	cache := New(Config{Capacity: 10})
+	for i := 0; i <= 9; i++ {
+		evict := cache.Set(i, i)
+		assert.False(t, evict)
+	}
+
+	assert.Equal(t, 10, cache.Len())
+}
+
+func TestClear(t *testing.T) {
+	cache := New(Config{Capacity: 10})
+	for i := 0; i <= 9; i++ {
+		evict := cache.Set(i, i)
+		assert.False(t, evict)
+	}
+
+	cache.Clear()
+
+	for i := 0; i <= 9; i++ {
+		_, ok := cache.Get(i)
+		assert.False(t, ok)
+	}
+	assert.Equal(t, 0, cache.Len())
+}
+
+func TestKeys(t *testing.T) {
+	cache := New(Config{Capacity: 10})
+	cache.Set("foo", 1)
+	cache.Set("bar", 2)
+
+	// key order isn't guarenteed
+	keys := cache.Keys()
+	sortedKeys := []string{keys[0].(string), keys[1].(string)}
+	sort.Strings(sortedKeys)
+
+	assert.Equal(t, 2, len(sortedKeys))
+	assert.Equal(t, "bar", sortedKeys[0])
+	assert.Equal(t, "foo", sortedKeys[1])
+}
+
+func TestOrderedKeys(t *testing.T) {
+	cache := New(Config{Capacity: 10})
+	cache.Set("foo", 1)
+	cache.Set("bar", 2)
+
+	keys := cache.OrderedKeys()
+
+	assert.Equal(t, 2, len(keys))
+	assert.Equal(t, "foo", keys[0])
+	assert.Equal(t, "bar", keys[1])
+}
+
+func TestSetMaxAge(t *testing.T) {
+	invalid, err := time.ParseDuration("-1h")
 	assert.Nil(t, err)
 
-	c.Add("foo", "bar")
-	c.Add("bar", "baz")
-	val, ok := c.Get("foo")
-	assert.False(t, ok)
-	assert.Nil(t, val)
-
-	val, ok = c.Get("bar")
-	assert.True(t, ok)
-	assert.Equal(t, val, "baz")
-}
-
-func TestError(t *testing.T) {
-	_, err := New(-1, time.Minute)
+	cache := New(Config{Capacity: 10})
+	err = cache.SetMaxAge(invalid)
 	assert.Error(t, err)
+
+	err = cache.SetMaxAge(time.Second)
+	assert.NoError(t, err)
 }
 
 func TestStats(t *testing.T) {
-	t.Run("increments hits", func(t *testing.T) {
-		c, err := New(100, time.Second)
-		if err != nil {
-			t.Fatalf("new: %s", err)
+	t.Run("reports capacity", func(t *testing.T) {
+		cache := New(Config{Capacity: 100})
+		assert.Equal(t, int64(100), cache.Stats().Capacity)
+	})
+
+	t.Run("reports count", func(t *testing.T) {
+		cache := New(Config{Capacity: 100})
+		for i := 0; i < 10; i++ {
+			cache.Set(i, i)
 		}
+		assert.Equal(t, int64(10), cache.Stats().Count)
+	})
 
-		c.Add("foo", "bar")
-		c.Get("foo")
+	t.Run("increments sets", func(t *testing.T) {
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		for i := 0; i < 10; i++ {
+			cache.Set("foo", "bar")
+		}
+		assert.Equal(t, int64(10), cache.Stats().Sets)
+	})
 
-		assert.Equal(t, Stats{Hits: 1}, c.Stats())
+	t.Run("increments gets", func(t *testing.T) {
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		for i := 0; i < 10; i++ {
+			cache.Get("foo")
+		}
+		assert.Equal(t, int64(10), cache.Stats().Gets)
+	})
+
+	t.Run("increments hits", func(t *testing.T) {
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		cache.Set("foo", "bar")
+		cache.Get("foo")
+		assert.Equal(t, int64(1), cache.Stats().Gets)
 	})
 
 	t.Run("increments misses", func(t *testing.T) {
-		c, err := New(100, time.Second)
-		if err != nil {
-			t.Fatalf("new: %s", err)
-		}
-
-		c.Get("foo")
-
-		assert.Equal(t, Stats{Misses: 1}, c.Stats())
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		cache.Get("foo")
+		assert.Equal(t, int64(1), cache.Stats().Misses)
 	})
 
-	t.Run("sub stats", func(t *testing.T) {
-		c, err := New(100, time.Second)
-		if err != nil {
-			t.Fatalf("new: %s", err)
+	t.Run("increments evictions", func(t *testing.T) {
+		cache := New(Config{Capacity: 1, MaxAge: time.Second})
+		for i := 0; i < 10; i++ {
+			cache.Set(i, i)
 		}
+		assert.Equal(t, int64(9), cache.Stats().Evictions)
+	})
 
-		c.Add("a", "1")
-
-		prev := c.Stats()
+	t.Run("delta stats", func(t *testing.T) {
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		cache.Set("a", "1")
+		prev := cache.Stats()
 
 		for i := 0; i < 10; i++ {
-			c.Get("a") // hit
-			c.Get("b") // miss
-			c.Get("a") // hit
+			cache.Get("a") // hit
+			cache.Get("b") // miss
+			cache.Get("a") // hit
 
-			stats := c.Stats().Sub(prev)
-			assert.Equal(t, Stats{Hits: 2, Misses: 1}, stats)
+			stats := cache.Stats().Delta(prev)
+			assert.Equal(t, int64(100), stats.Capacity)
+			assert.Equal(t, int64(1), stats.Count)
+			assert.Equal(t, int64(0), stats.Sets)
+			assert.Equal(t, int64(3), stats.Gets)
+			assert.Equal(t, int64(2), stats.Hits)
+			assert.Equal(t, int64(1), stats.Misses)
+			assert.Equal(t, int64(0), stats.Evictions)
 
-			prev = c.Stats()
+			prev = cache.Stats()
 		}
 	})
 
 	t.Run("copy", func(t *testing.T) {
-		c, err := New(100, time.Second)
-		if err != nil {
-			t.Fatalf("new: %s", err)
-		}
-
-		stats := c.Stats()
+		cache := New(Config{Capacity: 100, MaxAge: time.Second})
+		stats := cache.Stats()
 		stats.Hits++
 		stats.Misses++
 
-		assert.Equal(t, Stats{}, c.Stats())
+		assert.Equal(t, Stats{Capacity: 100}, cache.Stats())
 	})
 }
 
 func BenchmarkCache(b *testing.B) {
-	c, err := New(100, time.Second)
-	if err != nil {
-		b.Fatalf("new: %s", err)
-	}
+	cache := New(Config{Capacity: 100, MaxAge: time.Second})
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			c.Add("a", "b")
-			c.Get("a")
+			cache.Set("a", "b")
+			cache.Get("a")
 		}
 	})
 }


### PR DESCRIPTION
Was interested in using an LRU cache with max age when I came across this repo. Was hoping to make a few changes/additions if interested! This contains major breaking changes.

Though we haven't been tagging releases, this could correspond to a minor bump or major bump to v2.0 if we'd previously considered the API stable. Afaik, this is only used in two repos, both of which use govendor to pin the sha.

Changes:
```
* Added additional stats around cache capacity, count, sets, gets,
  and evictions
* Sub was renamed to Delta as not all stats are counters
* New now accepts a config object with optional fields
* New panics on invalid configuration
* Size was renamed to Capacity
* MaxAge is optional, and a duration of 0 disables expiration
* Configuration accepts two new optional callbacks: OnEviction and
  OnExpiration. The eviction callback is only invoked on LRU policy
  eviction, and not on element removal or expiration as seen in
  some other pkgs
* Add was renamed to Set since we overwrite any previous value
* Added new funcs: Has, Peek, Remove, Len, Clear, Keys, OrderedKeys,
  and SetMageAge
* Reduced allocations
```

```
// master
$ make bench
go test --bench=. --benchmem
BenchmarkCache-8   	 3000000	       431 ns/op	      80 B/op	       3 allocs/op
PASS
ok  	github.com/segmentio/agecache	1.751s

// PR
go test --bench=. --benchmem
BenchmarkCache-8   	 3000000	       405 ns/op	      32 B/op	       2 allocs/op
PASS
ok  	github.com/segmentio/agecache	1.661s
```

cc @segmentio/gateway 