### PR TITLE
Add active expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ statistics, as well as eviction and expiration callbacks. Differs from
 some implementations in that OnEviction is only invoked when an entry
 is removed as a result of the LRU eviction policy - not when you explicitly
 delete it or when it expires. OnExpiration is available and invoked when an
-item expires. Expiration is passively enforced when performing a Get.
+item expires. Expiration can be passively enforced when performing a Get,
+or actively enforced by iterating over all keys with an interval.
 
 ``` go
 cache := agecache.New(agecache.Config{

--- a/cache_test.go
+++ b/cache_test.go
@@ -261,6 +261,27 @@ func TestOnExpiration(t *testing.T) {
 	assert.True(t, expiration)
 }
 
+func TestActiveExpiration(t *testing.T) {
+	invoked := make(chan bool)
+
+	cache := New(Config{
+		Capacity:       1,
+		MaxAge:         time.Millisecond,
+		ExpirationType: ActiveExpiration,
+	})
+
+	cache.OnExpiration(func(key, value interface{}) {
+		invoked <- true
+	})
+
+	cache.Set("foo", 1)
+	start := time.Now()
+	<-invoked
+	duration := time.Now().Sub(start)
+
+	assert.True(t, duration < time.Millisecond*2)
+}
+
 func TestStats(t *testing.T) {
 	t.Run("reports capacity", func(t *testing.T) {
 		cache := New(Config{Capacity: 100})


### PR DESCRIPTION
Might later add an ActiveSamplingExpiration that samples a % of the keys, but for now iterating over the full map with 100,000 expired keys takes under 100ms.

cc @segmentio/gateway 