### PR TITLE
Add support for expiration jitter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test:
-	go test ./... -race -cover
+	go test ./... -v -race -cover
 
 bench:
 	go test --bench=. --benchmem

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agecache
 
-Thread-safe LRU cache supporting max age and expiration. Supports cache
+Thread-safe LRU cache supporting expiration and jitter. Supports cache
 statistics, as well as eviction and expiration callbacks. Differs from
 some implementations in that OnEviction is only invoked when an entry
 is removed as a result of the LRU eviction policy - not when you explicitly
@@ -11,7 +11,8 @@ or actively enforced by iterating over all keys with an interval.
 ``` go
 cache := agecache.New(agecache.Config{
 	Capacity: 100,
-	MaxAge:   time.Hour,
+	MaxAge:   70 * time.Minute,
+	MinAge:   60 * time.Minute,
 	OnExpiration: func(key, value interface{}) {
 		// Handle expiration
 	},


### PR DESCRIPTION
Adds jitter support to cache expiration. When fetching a random value for jitter, we simply use a uniform distribution, rather than a Gaussian distribution typically found in some systems.

``` go
cache := agecache.New(agecache.Config{
	Capacity: 100,
	MaxAge:   70 * time.Minute,
	MinAge:   60 * time.Minute,
})
```

The API continues to support dynamically changing the max age at runtime, however, the timestamp on object set no longer corresponds to the entry creation time.

I believe this is better than the following alternatives:
* If we stored the TTL/Expiry time instead, the API wouldn't support dynamically changing the max age at runtime and having it apply to existing objects. Removing that functionality would be a breaking change.
* If we applied the jitter during expiry check by adding it to the maxAge, the jitter could have little effect for frequently accessed keys.

cc @segmentio/schema 