### PR TITLE
convert to using generics

### DIFF
--- a/_example/stats.go
+++ b/_example/stats.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	cache := agecache.New(agecache.Config{
+	cache := agecache.New(agecache.Config[string, string]{
 		Capacity: 100,
 		MaxAge:   time.Second,
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/segmentio/agecache
+
+go 1.18
+
+require github.com/stretchr/testify v1.7.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This converts `agecache` to use Generics introduced in go1.18 for the `key` and `value`. It is a breaking change.

The advantages are:
- type safety guarantees
- better performance

before:
```go
go test --bench=. --benchmem
goos: darwin
goarch: amd64
pkg: github.com/deankarn/agecache
cpu: VirtualApple @ 2.50GHz
BenchmarkCache-8         2229212               537.5 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/deankarn/agecache    2.400s
```

after:
```go
go test --bench=. --benchmem
goos: darwin
goarch: amd64
pkg: github.com/deankarn/agecache
cpu: VirtualApple @ 2.50GHz
BenchmarkCache-8         2467549               483.2 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/deankarn/agecache    2.349s
```


 