### PR TITLE
add a LICENSE so that agecache package's docs will show up on the Godoc site

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2023 Twilio Segment
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
The README.md right now points to this godoc page:
* https://pkg.go.dev/github.com/segmentio/agecache

But that page contains an error saying the docs won't be shown because there isn't an accepable license in the repo.
* https://pkg.go.dev/license-policy

So add the MIT License, which is what we use for these packages:
* [kafka-go](https://github.com/segmentio/kafka-go/blob/172fe75936251b551c77c3b37d975b7d0f648a43/LICENSE)
* [chamber](https://github.com/segmentio/chamber/blob/301d5feb8dccca57c524ca2fda418f8aa96fcc9d/LICENSE)

Error:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1111441/217184395-55d9a1f8-92f8-4048-9107-7edda1f6fcc8.png">
