### PR TITLE
Add refresh cache functionality in agecache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -183,7 +183,11 @@ func New(config Config) *Cache {
 			defer t.Stop()
 			for {
 				<-t.C
-				cache.RefreshCache(config.OnRefresh())
+				items := config.OnRefresh()
+				// Only refresh the cache if the items provided is not nil
+				if items != nil {
+					cache.RefreshCache(items)
+				}
 			}
 		}()
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -143,6 +143,39 @@ func TestCacheBackgroundRefresh(t *testing.T) {
 
 }
 
+func TestCacheBackgroundRefreshForNilData(t *testing.T) {
+	count := 0
+	cache := New(Config{
+		Capacity:        1,
+		RefreshInterval: 3 * time.Second,
+		OnRefresh: func() map[interface{}]interface{} {
+			count++
+
+			if count == 2 {
+				return nil
+			}
+			return map[interface{}]interface{}{"key": count}
+		},
+	})
+
+	value, ok := cache.Get("key")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 1, value)
+
+	time.Sleep(4 * time.Second)
+
+	// Prevent refresh when the OnRefresh call back returns nil
+	value, ok = cache.Get("key")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 1, value)
+
+	time.Sleep(4 * time.Second)
+	value, ok = cache.Get("key")
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 3, value)
+
+}
+
 type MockRandGenerator struct {
 	startAt int64
 	incr    int64

--- a/cache_test.go
+++ b/cache_test.go
@@ -256,6 +256,29 @@ func TestClear(t *testing.T) {
 	assert.Equal(t, 0, cache.Len())
 }
 
+func TestRefreshCache(t *testing.T) {
+	cache := New(Config{Capacity: 10})
+	cache.Set("foo", 1)
+	cache.Set("bar", 2)
+
+	refreshedCacheEntries := map[interface{}]interface{}{}
+	for i := 0; i <= 9; i++ {
+		refreshedCacheEntries[i] = i
+	}
+	cache.RefreshCache(refreshedCacheEntries)
+
+	assert.False(t, cache.Has("foo"))
+	assert.False(t, cache.Has("bar"))
+
+	for i := 0; i <= 9; i++ {
+		_, ok := cache.Get(i)
+		assert.True(t, ok)
+	}
+
+	assert.Equal(t, 10, cache.Len())
+
+}
+
 func TestKeys(t *testing.T) {
 	cache := New(Config{Capacity: 10})
 	cache.Set("foo", 1)


### PR DESCRIPTION
[SRC-4124](https://segment.atlassian.net/browse/SRC-4124)

agecache can't refresh the whole cache currently. This PR intends to add this functionality.

[SRC-4124]: https://segment.atlassian.net/browse/SRC-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ